### PR TITLE
fixed option text issue with covid screener

### DIFF
--- a/covid_screener_stanford_survey/survey.tsv
+++ b/covid_screener_stanford_survey/survey.tsv
@@ -1,5 +1,5 @@
 question_type	question_text	required	page_number	option_text	option_values	variables
 instruction	Welcome to this survey. Press <strong>Next</strong> to begin.	0	1			
 instruction	Please answer the following questions.	0	2			
-textfield	"What is the date you received your final (or only, in the case of a single-dose vaccine) dose of the COVID-19 vaccine? (Mm/dd/yyyy)"	0	3			covid_screener_bl
+textfield	"What is the date you received your final (or only, in the case of a single-dose vaccine) dose of the COVID-19 vaccine? (Mm/dd/yyyy)"	1	3	covid_screener_bl		
 instruction	Congratulations for completing this survey! Press <strong>finish</strong> to continue.	0	4			


### PR DESCRIPTION
This should now take in an a value in the text field and let participants finish.